### PR TITLE
Use `C` locale instead of `en_US`

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -655,8 +655,8 @@ export class Git {
 
 		options.env = assign({}, process.env, this.env, options.env || {}, {
 			VSCODE_GIT_COMMAND: args[0],
-			LC_ALL: 'en_US.UTF-8',
-			LANG: 'en_US.UTF-8',
+			LC_ALL: 'C.UTF-8',
+			LANG: 'C.UTF-8',
 			GIT_PAGER: 'cat'
 		});
 


### PR DESCRIPTION
Not everybody speaks English and not everyone lives in the United States, so it is not given that `en_US` locale will be available on the system. `C`, however, must always be present on a (POSIX-compliant?) system, because it is selected as default on startup of the program, see https://man7.org/linux/man-pages/man3/setlocale.3.html The latter is therefore a much safer choice of a locale used to force English as output language, `.` as a decimal separator etc.

Resolves #189924.